### PR TITLE
Fixes include path failure.

### DIFF
--- a/include/inlines/eval.h
+++ b/include/inlines/eval.h
@@ -22,7 +22,7 @@
 #ifndef __EVAL_H__
 #define __EVAL_H__
 
-#include "poker_defs.h"
+#include "../poker_defs.h"
 #include <assert.h>
 
 /*

--- a/include/rules_std.h
+++ b/include/rules_std.h
@@ -27,7 +27,7 @@
 #ifndef __RULES_STD_H__
 #define __RULES_STD_H__
 
-#include <pokereval_export.h>
+#include "pokereval_export.h"
 
 #define StdRules_HandType_NOPAIR    0
 #define StdRules_HandType_ONEPAIR   1


### PR DESCRIPTION
Attempting to use the library headers from their make install location results
in <pokereval_export.h> being unfound. If make-installed, the location implied
by the chevrons would be <poker-eval/pokereval_export.h>, though I think the
standard method is just a relative path.

This is also a problem in the libpoker-eval-dev package, but I'm not sure if this is the same project.

Steps to reproduce:
1. Check out poker-eval.
2. Build and make install according to readme: 
   
   autoreconf --install
   ./configure
   make
   ./configure
   make install
3. Create a compile-able c program and `#include <poker-eval/poker_defs.h>`
4. Attempt to compile.

Perhaps this is the wrong header to include? I am using it because I saw it in the examples.
